### PR TITLE
Update random_walks.py

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -37,7 +37,6 @@ dependencies:
 - notebook>=0.5.0
 - numpydoc
 - nvcc_linux-64=11.8
-- ogb
 - openmpi
 - pip
 - pre-commit

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -398,6 +398,7 @@ add_library(cugraph_c
         src/c_api/induced_subgraph.cpp
         src/c_api/induced_subgraph_helper.cu
         src/c_api/graph_helper.cu
+        src/c_api/graph_generators.cpp
         src/c_api/induced_subgraph_result.cpp
         src/c_api/hits.cpp
         src/c_api/bfs.cpp

--- a/cpp/include/cugraph/graph_generators.hpp
+++ b/cpp/include/cugraph/graph_generators.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <raft/core/handle.hpp>
+#include <raft/random/rng_state.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <cstdint>
@@ -26,6 +28,8 @@ namespace cugraph {
 
 /**
  * @brief generate an edge list for an R-mat graph.
+ * @deprecated  This function will be deprectated and should be replaced with the version that takes
+ * raft::random::RngState as a parameter
  *
  * This function allows multi-edges and self-loops similar to the Graph 500 reference
  * implementation.
@@ -76,10 +80,59 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generat
   uint64_t seed      = 0,
   bool clip_and_flip = false);
 
+/**
+ * @brief generate an edge list for an R-mat graph.
+ *
+ * This function allows multi-edges and self-loops similar to the Graph 500 reference
+ * implementation.
+ *
+ * NOTE: The scramble_vertex_ids function needs to be called in order to generate a
+ * graph conforming to the Graph 500 specification (note that scrambling does not
+ * affect cuGraph's graph construction performance, so this is generally unnecessary).
+ * If `edge_factor` is given (e.g. Graph 500), set @p num_edges to
+ * (size_t{1} << @p scale) * `edge_factor`. To generate an undirected graph, set @p b == @p c and @p
+ * clip_and_flip = true. All the resulting edges will be placed in the lower triangular part
+ * (including the diagonal) of the graph adjacency matrix.
+ *
+ * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
+ * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
+ * handles to various CUDA libraries) to run graph algorithms.
+ * @param rng_state RAFT RNG state, updated with each call
+ * @param scale Scale factor to set the number of vertices in the graph. Vertex IDs have values in
+ * [0, V), where V = 1 << @p scale.
+ * @param num_edges Number of edges to generate.
+ * @param a a, b, c, d (= 1.0 - (a + b + c)) in the R-mat graph generator (vist https://graph500.org
+ * for additional details). a, b, c, d should be non-negative and a + b + c should be no larger
+ * than 1.0.
+ * @param b a, b, c, d (= 1.0 - (a + b + c)) in the R-mat graph generator (vist https://graph500.org
+ * for additional details). a, b, c, d should be non-negative and a + b + c should be no larger
+ * than 1.0.
+ * @param c a, b, c, d (= 1.0 - (a + b + c)) in the R-mat graph generator (vist https://graph500.org
+ * for additional details). a, b, c, d should be non-negative and a + b + c should be no larger
+ * than 1.0.
+ * @param clip_and_flip Flag controlling whether to generate edges only in the lower triangular part
+ * (including the diagonal) of the graph adjacency matrix (if set to `true`) or not (if set to
+ * `false`).
+ * @return std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> A tuple of
+ * rmm::device_uvector objects for edge source vertex IDs and edge destination vertex IDs.
+ */
+template <typename vertex_t>
+std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generate_rmat_edgelist(
+  raft::handle_t const& handle,
+  raft::random::RngState& rng_state,
+  size_t scale,
+  size_t num_edges,
+  double a           = 0.57,
+  double b           = 0.19,
+  double c           = 0.19,
+  bool clip_and_flip = false);
+
 enum class generator_distribution_t { POWER_LAW = 0, UNIFORM };
 
 /**
  * @brief generate multiple edge lists using the R-mat graph generator.
+ * @deprecated  This function will be deprectated and should be replaced with the version that takes
+ *raft::random::RngState as a parameter
  *
  * This function allows multi-edges and self-loops similar to the Graph 500 reference
  * implementation.
@@ -122,6 +175,52 @@ generate_rmat_edgelists(
   generator_distribution_t size_distribution = generator_distribution_t::POWER_LAW,
   generator_distribution_t edge_distribution = generator_distribution_t::POWER_LAW,
   uint64_t seed                              = 0,
+  bool clip_and_flip                         = false);
+
+/**
+ * @brief generate multiple edge lists using the R-mat graph generator.
+ *
+ * This function allows multi-edges and self-loops similar to the Graph 500 reference
+ * implementation.
+ *
+ * NOTE: The scramble_vertex_ids function needs to be called in order to generate a
+ * graph conforming to the Graph 500 specification (note that scrambling does not
+ * affect cuGraph's graph construction performance, so this is generally unnecessary).
+ * If `edge_factor` is given (e.g. Graph 500), set @p num_edges to
+ * (size_t{1} << @p scale) * `edge_factor`. To generate an undirected graph, set @p b == @p c and @p
+ * clip_and_flip = true. All the resulting edges will be placed in the lower triangular part
+ * (including the diagonal) of the graph adjacency matrix.
+ *
+ * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
+ * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
+ * handles to various CUDA libraries) to run graph algorithms.
+ * @param rng_state RAFT RNG state, updated with each call
+ * @param n_edgelists Number of edge lists (graphs) to generate
+ * @param min_scale Scale factor to set the minimum number of verties in the graph.
+ * @param max_scale Scale factor to set the maximum number of verties in the graph.
+ * @param edge_factor Average number of edges per vertex to generate.
+ * @param size_distribution Distribution of the graph sizes, impacts the scale parameter of the
+ * R-MAT generator
+ * @param edge_distribution Edges distribution for each graph, impacts how R-MAT parameters a,b,c,d,
+ * are set.
+ * @param clip_and_flip Flag controlling whether to generate edges only in the lower triangular part
+ * (including the diagonal) of the graph adjacency matrix (if set to `true`) or not (if set to
+ * `false`).
+ * @return A vector of std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> of
+ *size @p n_edgelists, each vector element being a tuple of rmm::device_uvector objects for edge
+ *source vertex IDs and edge destination vertex IDs.
+ */
+template <typename vertex_t>
+std::vector<std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>>>
+generate_rmat_edgelists(
+  raft::handle_t const& handle,
+  raft::random::RngState& rng_state,
+  size_t n_edgelists,
+  size_t min_scale,
+  size_t max_scale,
+  size_t edge_factor                         = 16,
+  generator_distribution_t size_distribution = generator_distribution_t::POWER_LAW,
+  generator_distribution_t edge_distribution = generator_distribution_t::POWER_LAW,
   bool clip_and_flip                         = false);
 
 /**

--- a/cpp/include/cugraph_c/graph_generators.h
+++ b/cpp/include/cugraph_c/graph_generators.h
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cugraph_c/array.h>
+#include <cugraph_c/graph.h>
+#include <cugraph_c/random.h>
+#include <cugraph_c/resource_handle.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum { POWER_LAW = 0, UNIFORM } cugraph_generator_distribution_t;
+
+/**
+ * @brief       Opaque COO definition
+ */
+typedef struct {
+  int32_t align_;
+} cugraph_coo_t;
+
+/**
+ * @brief       Opaque COO list definition
+ */
+typedef struct {
+  int32_t align_;
+} cugraph_coo_list_t;
+
+/**
+ * @brief       Get the source vertex ids
+ *
+ * @param [in]     coo   Opaque pointer to COO
+ * @return type erased array view of source vertex ids
+ */
+cugraph_type_erased_device_array_view_t* cugraph_coo_get_sources(cugraph_coo_t* coo);
+
+/**
+ * @brief       Get the destination vertex ids
+ *
+ * @param [in]     coo   Opaque pointer to COO
+ * @return type erased array view of destination vertex ids
+ */
+cugraph_type_erased_device_array_view_t* cugraph_coo_get_destinations(cugraph_coo_t* coo);
+
+/**
+ * @brief       Get the edge weights
+ *
+ * @param [in]     coo   Opaque pointer to COO
+ * @return type erased array view of edge weights, NULL if no edge weights in COO
+ */
+cugraph_type_erased_device_array_view_t* cugraph_coo_get_edge_weights(cugraph_coo_t* coo);
+
+/**
+ * @brief       Get the edge id
+ *
+ * @param [in]     coo   Opaque pointer to COO
+ * @return type erased array view of edge id, NULL if no edge ids in COO
+ */
+cugraph_type_erased_device_array_view_t* cugraph_coo_get_edge_id(cugraph_coo_t* coo);
+
+/**
+ * @brief       Get the edge type
+ *
+ * @param [in]     coo   Opaque pointer to COO
+ * @return type erased array view of edge type, NULL if no edge types in COO
+ */
+cugraph_type_erased_device_array_view_t* cugraph_coo_get_edge_type(cugraph_coo_t* coo);
+
+/**
+ * @brief       Get the number of coo object in the list
+ *
+ * @param [in]     coo_list   Opaque pointer to COO list
+ * @return number of elements
+ */
+size_t cugraph_coo_list_size(const cugraph_coo_list_t* coo_list);
+
+/**
+ * @brief       Get a COO from the list
+ *
+ * @param [in]     coo_list   Opaque pointer to COO list
+ * @param [in]     index      Index of desired COO from list
+ * @return a cugraph_coo_t* object from the list
+ */
+cugraph_coo_t* cugraph_coo_list_element(cugraph_coo_list_t* coo_list, size_t index);
+
+/**
+ * @brief     Free coo object
+ *
+ * @param [in]    coo Opaque pointer to COO
+ */
+void cugraph_coo_free(cugraph_coo_t* coo);
+
+/**
+ * @brief     Free coo list
+ *
+ * @param [in]    coo_list Opaque pointer to list of COO objects
+ */
+void cugraph_coo_list_free(cugraph_coo_list_t* coo_list);
+
+/**
+ * @brief      Generate RMAT edge list
+ *
+ * Returns a COO containing edges generated from the RMAT generator.
+ *
+ * Vertex types will be int32 if scale < 32 and int64 if scale >= 32
+ *
+ * @param [in]     handle             Handle for accessing resources
+ * @param [in/out] rng_state          State of the random number generator, updated with each call
+ * @param [in]     scale Scale factor to set the number of vertices in the graph. Vertex IDs have
+ * values in [0, V), where V = 1 << @p scale.
+ * @param [in]     num_edges          Number of edges to generate.
+ * @param [in]     a                  a, b, c, d (= 1.0 - (a + b + c)) in the R-mat graph generator
+ * (vist https://graph500.org for additional details). a, b, c, d should be non-negative and a + b +
+ * c should be no larger than 1.0.
+ * @param [in]     b                  a, b, c, d (= 1.0 - (a + b + c)) in the R-mat graph generator
+ * (vist https://graph500.org for additional details). a, b, c, d should be non-negative and a + b +
+ * c should be no larger than 1.0.
+ * @param [in]     c                  a, b, c, d (= 1.0 - (a + b + c)) in the R-mat graph generator
+ * (vist https://graph500.org for additional details). a, b, c, d should be non-negative and a + b +
+ * c should be no larger than 1.0.
+ * @param [in]     clip_and_flip      Flag controlling whether to generate edges only in the lower
+ * triangular part (including the diagonal) of the graph adjacency matrix (if set to `true`) or not
+ * (if set to `false`).
+ * @param [out]    result             Opaque pointer to generated coo
+ * @param [out]    error              Pointer to an error object storing details of any error.  Will
+ *                                    be populated if error code is not CUGRAPH_SUCCESS
+ * @return error code
+ */
+cugraph_error_code_t cugraph_generate_rmat_edgelist(const cugraph_resource_handle_t* handle,
+                                                    cugraph_rng_state_t* rng_state,
+                                                    size_t scale,
+                                                    size_t num_edges,
+                                                    double a,
+                                                    double b,
+                                                    double c,
+                                                    bool_t clip_and_flip,
+                                                    cugraph_coo_t** result,
+                                                    cugraph_error_t** error);
+
+/**
+ * @brief      Generate RMAT edge lists
+ *
+ * Returns a COO list containing edges generated from the RMAT generator.
+ *
+ * Vertex types will be int32 if scale < 32 and int64 if scale >= 32
+ *
+ * @param [in]     handle             Handle for accessing resources
+ * @param [in/out] rng_state          State of the random number generator, updated with each call
+ * @param [in]     n_edgelists Number of edge lists (graphs) to generate
+ * @param [in]     min_scale Scale factor to set the minimum number of verties in the graph.
+ * @param [in]     max_scale Scale factor to set the maximum number of verties in the graph.
+ * @param [in]     edge_factor Average number of edges per vertex to generate.
+ * @param [in]     size_distribution Distribution of the graph sizes, impacts the scale parameter of
+ * the R-MAT generator
+ * @param [in]     edge_distribution Edges distribution for each graph, impacts how R-MAT parameters
+ * a,b,c,d, are set.
+ * @param [in]     clip_and_flip      Flag controlling whether to generate edges only in the lower
+ * triangular part (including the diagonal) of the graph adjacency matrix (if set to `true`) or not
+ * (if set to `false`).
+ * @param [out]    result             Opaque pointer to generated coo list
+ * @param [out]    error              Pointer to an error object storing details of any error.  Will
+ *                                    be populated if error code is not CUGRAPH_SUCCESS
+ * @return error code
+ */
+cugraph_error_code_t cugraph_generate_rmat_edgelists(
+  const cugraph_resource_handle_t* handle,
+  cugraph_rng_state_t* rng_state,
+  size_t n_edgelists,
+  size_t min_scale,
+  size_t max_scale,
+  size_t edge_factor,
+  cugraph_generator_distribution_t size_distribution,
+  cugraph_generator_distribution_t edge_distribution,
+  bool_t clip_and_flip,
+  cugraph_coo_list_t** result,
+  cugraph_error_t** error);
+
+/**
+ * @brief      Generate edge weights and add to an rmat edge list
+ *
+ * Updates a COO to contain random edge weights
+ *
+ * @param [in]     handle             Handle for accessing resources
+ * @param [in/out] rng_state          State of the random number generator, updated with each call
+ * @param [in/out] coo                Opaque pointer to the coo, weights will be added (overwriting
+ * any existing weights)
+ * @param [in]     dtype              The type of weight to generate (FLOAT32 or FLOAT64), ignored
+ * unless include_weights is true
+ * @param [in]     minimum_weight     Minimum weight value to generate
+ * @param [in]     maximum_weight     Maximum weight value to generate
+ * @param [out]    error              Pointer to an error object storing details of any error.  Will
+ *                                    be populated if error code is not CUGRAPH_SUCCESS
+ */
+cugraph_error_code_t cugraph_generate_edge_weights(const cugraph_resource_handle_t* handle,
+                                                   cugraph_rng_state_t* rng_state,
+                                                   cugraph_coo_t* coo,
+                                                   cugraph_data_type_id_t dtype,
+                                                   double minimum_weight,
+                                                   double maximum_weight,
+                                                   cugraph_error_t** error);
+
+/**
+ * @brief      Add edge ids to an COO
+ *
+ * Updates a COO to contain edge ids.  Edges will be numbered from 0 to n-1 where n is the number of
+ * edges
+ *
+ * @param [in]     handle             Handle for accessing resources
+ * @param [in/out] coo                Opaque pointer to the coo, weights will be added (overwriting
+ * any existing weights)
+ * @param [in]     multi_gpu          Flag if the COO is being created on multiple GPUs
+ * @param [out]    error              Pointer to an error object storing details of any error.  Will
+ *                                    be populated if error code is not CUGRAPH_SUCCESS
+ */
+cugraph_error_code_t cugraph_generate_edge_ids(const cugraph_resource_handle_t* handle,
+                                               cugraph_coo_t* coo,
+                                               bool_t multi_gpu,
+                                               cugraph_error_t** error);
+
+/**
+ * @brief      Generate random edge types, add them to an COO
+ *
+ * Updates a COO to contain edge types.  Edges types will be randomly generated.
+ *
+ * @param [in]     handle             Handle for accessing resources
+ * @param [in/out] rng_state          State of the random number generator, updated with each call
+ * @param [in/out] coo                Opaque pointer to the coo, weights will be added (overwriting
+ * any existing weights)
+ * @param [in]     max_edge_type      Edge types will be randomly generated between min_edge_type
+ * and max_edge_type
+ * @param [out]    error              Pointer to an error object storing details of any error.  Will
+ *                                    be populated if error code is not CUGRAPH_SUCCESS
+ */
+cugraph_error_code_t cugraph_generate_edge_types(const cugraph_resource_handle_t* handle,
+                                                 cugraph_rng_state_t* rng_state,
+                                                 cugraph_coo_t* coo,
+                                                 int32_t min_edge_type,
+                                                 int32_t max_edge_type,
+                                                 cugraph_error_t** error);
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/src/c_api/graph_generators.cpp
+++ b/cpp/src/c_api/graph_generators.cpp
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cugraph_c/graph_generators.h>
+
+#include <c_api/array.hpp>
+#include <c_api/error.hpp>
+#include <c_api/random.hpp>
+#include <c_api/resource_handle.hpp>
+
+#include <cugraph/detail/utility_wrappers.hpp>
+#include <cugraph/graph_generators.hpp>
+#include <cugraph/utilities/host_scalar_comm.hpp>
+
+#include <raft/core/handle.hpp>
+
+namespace cugraph {
+namespace c_api {
+
+struct cugraph_coo_t {
+  std::unique_ptr<cugraph_type_erased_device_array_t> src_{};
+  std::unique_ptr<cugraph_type_erased_device_array_t> dst_{};
+  std::unique_ptr<cugraph_type_erased_device_array_t> wgt_{};
+  std::unique_ptr<cugraph_type_erased_device_array_t> id_{};
+  std::unique_ptr<cugraph_type_erased_device_array_t> type_{};
+};
+
+struct cugraph_coo_list_t {
+  std::vector<std::unique_ptr<cugraph_coo_t>> list_;
+};
+
+}  // namespace c_api
+}  // namespace cugraph
+
+namespace {
+
+template <typename vertex_t>
+cugraph_error_code_t cugraph_generate_rmat_edgelist(raft::handle_t const& handle,
+                                                    raft::random::RngState& rng_state,
+                                                    cugraph_data_type_id_t vertex_dtype,
+                                                    size_t scale,
+                                                    size_t num_edges,
+                                                    double a,
+                                                    double b,
+                                                    double c,
+                                                    bool_t clip_and_flip,
+                                                    cugraph::c_api::cugraph_coo_t** result,
+                                                    cugraph::c_api::cugraph_error_t** error)
+{
+  try {
+    auto [src, dst] = cugraph::generate_rmat_edgelist<vertex_t>(
+      handle, rng_state, scale, num_edges, a, b, c, clip_and_flip);
+
+    *result = new cugraph::c_api::cugraph_coo_t{
+      std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(src, vertex_dtype),
+      std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(dst, vertex_dtype),
+      nullptr,
+      nullptr,
+      nullptr};
+
+  } catch (std::exception const& ex) {
+    *error = new cugraph::c_api::cugraph_error_t{ex.what()};
+    return CUGRAPH_UNKNOWN_ERROR;
+  }
+
+  return CUGRAPH_SUCCESS;
+}
+
+template <typename vertex_t>
+cugraph_error_code_t cugraph_generate_rmat_edgelists(
+  raft::handle_t const& handle,
+  raft::random::RngState& rng_state,
+  cugraph_data_type_id_t vertex_dtype,
+  size_t n_edgelists,
+  size_t min_scale,
+  size_t max_scale,
+  size_t edge_factor,
+  cugraph_generator_distribution_t size_distribution,
+  cugraph_generator_distribution_t edge_distribution,
+  bool_t clip_and_flip,
+  cugraph::c_api::cugraph_coo_list_t** result,
+  cugraph::c_api::cugraph_error_t** error)
+{
+  try {
+    auto tuple_vector = cugraph::generate_rmat_edgelists<vertex_t>(
+      handle,
+      rng_state,
+      n_edgelists,
+      min_scale,
+      max_scale,
+      edge_factor,
+      static_cast<cugraph::generator_distribution_t>(size_distribution),
+      static_cast<cugraph::generator_distribution_t>(edge_distribution),
+      clip_and_flip);
+
+    *result = new cugraph::c_api::cugraph_coo_list_t;
+    (*result)->list_.resize(tuple_vector.size());
+
+    std::transform(
+      tuple_vector.begin(),
+      tuple_vector.end(),
+      (*result)->list_.begin(),
+      [vertex_dtype](auto& tuple) {
+        auto result = std::make_unique<cugraph::c_api::cugraph_coo_t>();
+
+        auto& src = std::get<0>(tuple);
+        auto& dst = std::get<1>(tuple);
+
+        result->src_ =
+          std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(src, vertex_dtype);
+        result->dst_ =
+          std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(dst, vertex_dtype);
+
+        return result;
+      });
+
+    return CUGRAPH_SUCCESS;
+  } catch (std::exception const& ex) {
+    *error = new cugraph::c_api::cugraph_error_t{ex.what()};
+    return CUGRAPH_UNKNOWN_ERROR;
+  }
+}
+
+}  // namespace
+
+extern "C" cugraph_type_erased_device_array_view_t* cugraph_coo_get_sources(cugraph_coo_t* coo)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(internal_pointer->src_->view());
+}
+
+extern "C" cugraph_type_erased_device_array_view_t* cugraph_coo_get_destinations(cugraph_coo_t* coo)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(internal_pointer->dst_->view());
+}
+
+extern "C" cugraph_type_erased_device_array_view_t* cugraph_coo_get_edge_weights(cugraph_coo_t* coo)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(internal_pointer->wgt_->view());
+}
+
+extern "C" cugraph_type_erased_device_array_view_t* cugraph_coo_get_edge_id(cugraph_coo_t* coo)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(internal_pointer->id_->view());
+}
+
+extern "C" cugraph_type_erased_device_array_view_t* cugraph_coo_get_edge_type(cugraph_coo_t* coo)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
+    internal_pointer->type_->view());
+}
+
+extern "C" size_t cugraph_coo_list_size(const cugraph_coo_list_t* coo_list)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_list_t const*>(coo_list);
+  return internal_pointer->list_.size();
+}
+
+extern "C" cugraph_coo_t* cugraph_coo_list_element(cugraph_coo_list_t* coo_list, size_t index)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_list_t*>(coo_list);
+  return reinterpret_cast<::cugraph_coo_t*>(
+    (index < internal_pointer->list_.size()) ? internal_pointer->list_[index].get() : nullptr);
+}
+
+extern "C" void cugraph_coo_free(cugraph_coo_t* coo)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+  delete internal_pointer;
+}
+
+extern "C" void cugraph_coo_list_free(cugraph_coo_list_t* coo_list)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_coo_list_t*>(coo_list);
+  delete internal_pointer;
+}
+
+extern "C" cugraph_error_code_t cugraph_generate_rmat_edgelist(
+  const cugraph_resource_handle_t* handle,
+  cugraph_rng_state_t* rng_state,
+  size_t scale,
+  size_t num_edges,
+  double a,
+  double b,
+  double c,
+  bool_t clip_and_flip,
+  cugraph_coo_t** result,
+  cugraph_error_t** error)
+{
+  auto& local_handle{
+    *reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_};
+  auto& local_rng_state{
+    reinterpret_cast<cugraph::c_api::cugraph_rng_state_t*>(rng_state)->rng_state_};
+
+  if (scale < 32) {
+    return cugraph_generate_rmat_edgelist<int32_t>(
+      local_handle,
+      local_rng_state,
+      cugraph_data_type_id_t::INT32,
+      scale,
+      num_edges,
+      a,
+      b,
+      c,
+      clip_and_flip,
+      reinterpret_cast<cugraph::c_api::cugraph_coo_t**>(result),
+      reinterpret_cast<cugraph::c_api::cugraph_error_t**>(error));
+  } else {
+    return cugraph_generate_rmat_edgelist<int64_t>(
+      local_handle,
+      local_rng_state,
+      cugraph_data_type_id_t::INT64,
+      scale,
+      num_edges,
+      a,
+      b,
+      c,
+      clip_and_flip,
+      reinterpret_cast<cugraph::c_api::cugraph_coo_t**>(result),
+      reinterpret_cast<cugraph::c_api::cugraph_error_t**>(error));
+  }
+}
+
+extern "C" cugraph_error_code_t cugraph_generate_rmat_edgelists(
+  const cugraph_resource_handle_t* handle,
+  cugraph_rng_state_t* rng_state,
+  size_t n_edgelists,
+  size_t min_scale,
+  size_t max_scale,
+  size_t edge_factor,
+  cugraph_generator_distribution_t size_distribution,
+  cugraph_generator_distribution_t edge_distribution,
+  bool_t clip_and_flip,
+  cugraph_coo_list_t** result,
+  cugraph_error_t** error)
+{
+  auto& local_handle{
+    *reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_};
+  auto& local_rng_state{
+    reinterpret_cast<cugraph::c_api::cugraph_rng_state_t*>(rng_state)->rng_state_};
+
+  if (max_scale < 32) {
+    return cugraph_generate_rmat_edgelists<int32_t>(
+      local_handle,
+      local_rng_state,
+      cugraph_data_type_id_t::INT32,
+      n_edgelists,
+      min_scale,
+      max_scale,
+      edge_factor,
+      size_distribution,
+      edge_distribution,
+      clip_and_flip,
+      reinterpret_cast<cugraph::c_api::cugraph_coo_list_t**>(result),
+      reinterpret_cast<cugraph::c_api::cugraph_error_t**>(error));
+  } else {
+    return cugraph_generate_rmat_edgelists<int64_t>(
+      local_handle,
+      local_rng_state,
+      cugraph_data_type_id_t::INT64,
+      n_edgelists,
+      min_scale,
+      max_scale,
+      edge_factor,
+      size_distribution,
+      edge_distribution,
+      clip_and_flip,
+      reinterpret_cast<cugraph::c_api::cugraph_coo_list_t**>(result),
+      reinterpret_cast<cugraph::c_api::cugraph_error_t**>(error));
+  }
+}
+
+extern "C" cugraph_error_code_t cugraph_generate_edge_weights(
+  const cugraph_resource_handle_t* handle,
+  cugraph_rng_state_t* rng_state,
+  cugraph_coo_t* coo,
+  cugraph_data_type_id_t dtype,
+  double minimum_weight,
+  double maximum_weight,
+  cugraph_error_t** error)
+{
+  auto& local_handle{
+    *reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_};
+  auto& local_rng_state{
+    reinterpret_cast<cugraph::c_api::cugraph_rng_state_t*>(rng_state)->rng_state_};
+
+  auto local_coo = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+
+  switch (dtype) {
+    case cugraph_data_type_id_t::FLOAT32: {
+      rmm::device_uvector<float> tmp(local_coo->src_->size_, local_handle.get_stream());
+      cugraph::detail::uniform_random_fill(local_handle.get_stream(),
+                                           tmp.data(),
+                                           tmp.size(),
+                                           static_cast<float>(minimum_weight),
+                                           static_cast<float>(maximum_weight),
+                                           local_rng_state);
+      local_coo->wgt_ =
+        std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(tmp, dtype);
+      break;
+    }
+    case cugraph_data_type_id_t::FLOAT64: {
+      rmm::device_uvector<double> tmp(local_coo->src_->size_, local_handle.get_stream());
+      cugraph::detail::uniform_random_fill(local_handle.get_stream(),
+                                           tmp.data(),
+                                           tmp.size(),
+                                           minimum_weight,
+                                           maximum_weight,
+                                           local_rng_state);
+      local_coo->wgt_ =
+        std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(tmp, dtype);
+      break;
+    }
+    otherwise : {
+      *error = reinterpret_cast<::cugraph_error_t*>(new cugraph::c_api::cugraph_error_t(
+        "Only FLOAT and DOUBLE supported as generated edge weights"));
+      return CUGRAPH_INVALID_INPUT;
+    }
+  }
+
+  return CUGRAPH_SUCCESS;
+}
+
+extern "C" cugraph_error_code_t cugraph_generate_edge_ids(const cugraph_resource_handle_t* handle,
+                                                          cugraph_coo_t* coo,
+                                                          bool_t multi_gpu,
+                                                          cugraph_error_t** error)
+{
+  auto& local_handle{
+    *reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_};
+
+  auto local_coo = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+
+  constexpr size_t int32_threshold{std::numeric_limits<int32_t>::max()};
+
+  size_t num_edges{local_coo->src_->size_};
+  size_t base_edge_id{0};
+
+  if (multi_gpu) {
+    auto edge_counts = cugraph::host_scalar_allgather(
+      local_handle.get_comms(), num_edges, local_handle.get_stream());
+    std::vector<size_t> edge_starts(edge_counts.size());
+
+    std::exclusive_scan(edge_counts.begin(), edge_counts.end(), edge_starts.begin(), size_t{0});
+
+    num_edges    = edge_starts.back() + edge_counts.back();
+    base_edge_id = edge_starts[local_handle.get_comms().get_rank()];
+  }
+
+  if (num_edges < int32_threshold) {
+    rmm::device_uvector<int32_t> tmp(local_coo->src_->size_, local_handle.get_stream());
+
+    cugraph::detail::sequence_fill(
+      local_handle.get_stream(), tmp.data(), tmp.size(), static_cast<int32_t>(base_edge_id));
+
+    local_coo->id_ = std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(
+      tmp, cugraph_data_type_id_t::INT32);
+  } else {
+    rmm::device_uvector<int64_t> tmp(local_coo->src_->size_, local_handle.get_stream());
+
+    cugraph::detail::sequence_fill(
+      local_handle.get_stream(), tmp.data(), tmp.size(), static_cast<int64_t>(base_edge_id));
+
+    local_coo->id_ = std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(
+      tmp, cugraph_data_type_id_t::INT64);
+  }
+
+  return CUGRAPH_SUCCESS;
+}
+
+extern "C" cugraph_error_code_t cugraph_generate_edge_types(const cugraph_resource_handle_t* handle,
+                                                            cugraph_rng_state_t* rng_state,
+                                                            cugraph_coo_t* coo,
+                                                            int32_t min_edge_type,
+                                                            int32_t max_edge_type,
+                                                            cugraph_error_t** error)
+{
+  auto& local_handle{
+    *reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_};
+  auto& local_rng_state{
+    reinterpret_cast<cugraph::c_api::cugraph_rng_state_t*>(rng_state)->rng_state_};
+
+  auto local_coo = reinterpret_cast<cugraph::c_api::cugraph_coo_t*>(coo);
+
+  rmm::device_uvector<int32_t> tmp(local_coo->src_->size_, local_handle.get_stream());
+  cugraph::detail::uniform_random_fill(local_handle.get_stream(),
+                                       tmp.data(),
+                                       tmp.size(),
+                                       min_edge_type,
+                                       max_edge_type,
+                                       local_rng_state);
+  local_coo->type_ = std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(
+    tmp, cugraph_data_type_id_t::INT32);
+
+  return CUGRAPH_SUCCESS;
+}

--- a/cpp/src/generators/generate_rmat_edgelist.cu
+++ b/cpp/src/generators/generate_rmat_edgelist.cu
@@ -19,6 +19,8 @@
 #include <cugraph/utilities/error.hpp>
 
 #include <raft/core/handle.hpp>
+#include <raft/random/rng.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
@@ -26,7 +28,6 @@
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
-#include <random>
 #include <rmm/detail/error.hpp>
 #include <tuple>
 
@@ -35,12 +36,12 @@ namespace cugraph {
 template <typename vertex_t>
 std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generate_rmat_edgelist(
   raft::handle_t const& handle,
+  raft::random::RngState& rng_state,
   size_t scale,
   size_t num_edges,
   double a,
   double b,
   double c,
-  uint64_t seed,
   bool clip_and_flip)
 {
   CUGRAPH_EXPECTS((size_t{1} << scale) <= static_cast<size_t>(std::numeric_limits<vertex_t>::max()),
@@ -65,11 +66,8 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generat
     auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(srcs.begin(), dsts.begin())) +
                       num_edges_generated;
 
-    // FIXME: This should be passed as a parameter instead of the seed
-    raft::random::RngState rng_state(seed);
     detail::uniform_random_fill(
       handle.get_stream(), rands.data(), num_edges_to_generate * 2 * scale, 0.0f, 1.0f, rng_state);
-    seed += num_edges_to_generate * 2 * scale;
 
     thrust::transform(
       handle.get_thrust_policy(),
@@ -110,15 +108,32 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generat
 }
 
 template <typename vertex_t>
+std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generate_rmat_edgelist(
+  raft::handle_t const& handle,
+  size_t scale,
+  size_t num_edges,
+  double a,
+  double b,
+  double c,
+  uint64_t seed,
+  bool clip_and_flip)
+{
+  raft::random::RngState rng_state(seed);
+
+  return generate_rmat_edgelist<vertex_t>(
+    handle, rng_state, scale, num_edges, a, b, c, clip_and_flip);
+}
+
+template <typename vertex_t>
 std::vector<std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>>>
 generate_rmat_edgelists(raft::handle_t const& handle,
+                        raft::random::RngState& rng_state,
                         size_t n_edgelists,
                         size_t min_scale,
                         size_t max_scale,
                         size_t edge_factor,
-                        generator_distribution_t component_distribution,
+                        generator_distribution_t size_distribution,
                         generator_distribution_t edge_distribution,
-                        uint64_t seed,
                         bool clip_and_flip)
 {
   CUGRAPH_EXPECTS(min_scale > 0, "minimum graph scale is 1.");
@@ -129,22 +144,33 @@ generate_rmat_edgelists(raft::handle_t const& handle,
   std::vector<std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>>> output{};
   output.reserve(n_edgelists);
   std::vector<vertex_t> scale(n_edgelists);
+  rmm::device_uvector<vertex_t> d_scale(n_edgelists, handle.get_stream());
 
-  std::default_random_engine eng;
-  eng.seed(seed);
-  if (component_distribution == generator_distribution_t::UNIFORM) {
-    std::uniform_int_distribution<vertex_t> dist(min_scale, max_scale);
-    std::generate(scale.begin(), scale.end(), [&dist, &eng]() { return dist(eng); });
+  if (size_distribution == generator_distribution_t::UNIFORM) {
+    detail::uniform_random_fill(handle.get_stream(),
+                                d_scale.data(),
+                                d_scale.size(),
+                                static_cast<vertex_t>(min_scale),
+                                static_cast<vertex_t>(max_scale),
+                                rng_state);
   } else {
-    // May expose this as a parameter in the future
-    std::exponential_distribution<float> dist(4);
+    // May expose lambda as a parameter in the future
+    rmm::device_uvector<float> rand(n_edgelists, handle.get_stream());
+    raft::random::exponential(handle, rng_state, rand.data(), rand.size(), float{4});
     // The modulo is here to protect the range because exponential distribution is defined on
     // [0,infinity). With exponent 4 most values are between 0 and 1
     auto range = max_scale - min_scale;
-    std::generate(scale.begin(), scale.end(), [&dist, &eng, &min_scale, &range]() {
-      return min_scale + static_cast<vertex_t>(static_cast<float>(range) * dist(eng)) % range;
-    });
+    thrust::transform(handle.get_thrust_policy(),
+                      rand.begin(),
+                      rand.end(),
+                      d_scale.begin(),
+                      [min_scale, range] __device__(auto rnd) {
+                        return min_scale +
+                               static_cast<vertex_t>(static_cast<float>(range) * rnd) % range;
+                      });
   }
+
+  raft::update_host(scale.data(), d_scale.data(), d_scale.size(), handle.get_stream());
 
   // intialized to standard powerlaw values
   double a = 0.57, b = 0.19, c = 0.19;
@@ -156,11 +182,79 @@ generate_rmat_edgelists(raft::handle_t const& handle,
 
   for (size_t i = 0; i < n_edgelists; i++) {
     output.push_back(generate_rmat_edgelist<vertex_t>(
-      handle, scale[i], scale[i] * edge_factor, a, b, c, i, clip_and_flip));
+      handle, rng_state, scale[i], scale[i] * edge_factor, a, b, c, clip_and_flip));
   }
   return output;
 }
 
+template <typename vertex_t>
+std::vector<std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>>>
+generate_rmat_edgelists(raft::handle_t const& handle,
+                        size_t n_edgelists,
+                        size_t min_scale,
+                        size_t max_scale,
+                        size_t edge_factor,
+                        generator_distribution_t size_distribution,
+                        generator_distribution_t edge_distribution,
+                        uint64_t seed,
+                        bool clip_and_flip)
+{
+  raft::random::RngState rng_state(seed);
+
+  return generate_rmat_edgelists<vertex_t>(handle,
+                                           rng_state,
+                                           n_edgelists,
+                                           min_scale,
+                                           max_scale,
+                                           edge_factor,
+                                           size_distribution,
+                                           edge_distribution,
+                                           clip_and_flip);
+}
+
+template std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<int32_t>>
+generate_rmat_edgelist<int32_t>(raft::handle_t const& handle,
+                                raft::random::RngState& rng_state,
+                                size_t scale,
+                                size_t num_edges,
+                                double a,
+                                double b,
+                                double c,
+                                bool clip_and_flip);
+
+template std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<int64_t>>
+generate_rmat_edgelist<int64_t>(raft::handle_t const& handle,
+                                raft::random::RngState& rng_state,
+                                size_t scale,
+                                size_t num_edges,
+                                double a,
+                                double b,
+                                double c,
+                                bool clip_and_flip);
+
+template std::vector<std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<int32_t>>>
+generate_rmat_edgelists<int32_t>(raft::handle_t const& handle,
+                                 raft::random::RngState& rng_state,
+                                 size_t n_edgelists,
+                                 size_t min_scale,
+                                 size_t max_scale,
+                                 size_t edge_factor,
+                                 generator_distribution_t size_distribution,
+                                 generator_distribution_t edge_distribution,
+                                 bool clip_and_flip);
+
+template std::vector<std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<int64_t>>>
+generate_rmat_edgelists<int64_t>(raft::handle_t const& handle,
+                                 raft::random::RngState& rng_state,
+                                 size_t n_edgelists,
+                                 size_t min_scale,
+                                 size_t max_scale,
+                                 size_t edge_factor,
+                                 generator_distribution_t size_distribution,
+                                 generator_distribution_t edge_distribution,
+                                 bool clip_and_flip);
+
+/* DEPRECATED */
 template std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<int32_t>>
 generate_rmat_edgelist<int32_t>(raft::handle_t const& handle,
                                 size_t scale,
@@ -187,7 +281,7 @@ generate_rmat_edgelists<int32_t>(raft::handle_t const& handle,
                                  size_t min_scale,
                                  size_t max_scale,
                                  size_t edge_factor,
-                                 generator_distribution_t component_distribution,
+                                 generator_distribution_t size_distribution,
                                  generator_distribution_t edge_distribution,
                                  uint64_t seed,
                                  bool clip_and_flip);
@@ -198,7 +292,7 @@ generate_rmat_edgelists<int64_t>(raft::handle_t const& handle,
                                  size_t min_scale,
                                  size_t max_scale,
                                  size_t edge_factor,
-                                 generator_distribution_t component_distribution,
+                                 generator_distribution_t size_distribution,
                                  generator_distribution_t edge_distribution,
                                  uint64_t seed,
                                  bool clip_and_flip);

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -576,6 +576,7 @@ if(BUILD_CUGRAPH_MG_TESTS)
     ###############################################################################################
     # - MG C API tests ----------------------------------------------------------------------------
     ConfigureCTestMG(MG_CAPI_CREATE_GRAPH_TEST c_api/mg_create_graph_test.c c_api/mg_test_utils.cpp)
+    ConfigureCTestMG(MG_CAPI_GENERATE_RMAT_TEST c_api/mg_generate_rmat_test.c c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_PAGERANK_TEST c_api/mg_pagerank_test.c c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_BFS_TEST c_api/mg_bfs_test.c c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_SSSP_TEST c_api/mg_sssp_test.c c_api/mg_test_utils.cpp)
@@ -627,6 +628,7 @@ target_link_libraries(cugraph_c_testutil
 
 
 ConfigureCTest(CAPI_CREATE_GRAPH_TEST c_api/create_graph_test.c)
+ConfigureCTest(CAPI_GENERATE_RMAT_TEST c_api/generate_rmat_test.c)
 ConfigureCTest(CAPI_PAGERANK_TEST c_api/pagerank_test.c)
 ConfigureCTest(CAPI_KATZ_TEST c_api/katz_test.c)
 ConfigureCTest(CAPI_EIGENVECTOR_CENTRALITY_TEST c_api/eigenvector_centrality_test.c)

--- a/cpp/tests/c_api/generate_rmat_test.c
+++ b/cpp/tests/c_api/generate_rmat_test.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "c_test_utils.h" /* RUN_TEST */
+
+#include <cugraph_c/graph_generators.h>
+
+#include <stdio.h>
+
+/*
+ * Simple rmat generator test
+ */
+int test_rmat_generation()
+{
+  int test_ret_value = 0;
+
+  typedef int32_t vertex_t;
+  typedef int32_t edge_t;
+  typedef float weight_t;
+
+  vertex_t expected_src[] =  { 17, 18, 0, 16, 1, 24, 16, 1, 6, 4, 2, 1, 14, 2, 16, 2, 5, 23, 4, 10, 4, 3, 0, 4, 11, 0, 0, 2, 24, 0};
+  vertex_t expected_dst[] = { 0, 10, 23, 0, 26, 0, 2, 1, 27, 8, 1, 0, 21, 21, 0, 4, 8, 14, 10, 17, 0, 16, 0, 16, 25, 5, 8, 8, 4, 19}; 
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error;
+
+  cugraph_resource_handle_t* handle = NULL;
+  cugraph_rng_state_t *rng_state    = NULL;;
+  cugraph_coo_t *coo = NULL;
+
+  handle = cugraph_create_resource_handle(NULL);
+  TEST_ASSERT(test_ret_value, handle != NULL, "resource handle creation failed.");
+
+  ret_code = cugraph_rng_state_create(handle, 0, &rng_state, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "rng_state create failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+ 
+  ret_code = cugraph_generate_rmat_edgelist(handle,
+                                            rng_state,
+                                            5,
+                                            30,
+                                            0.57,
+                                            0.19,
+                                            0.19,
+                                            FALSE,
+                                            &coo,
+                                            &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "generate_rmat_edgelist failed.");
+
+  cugraph_type_erased_device_array_view_t* src_view;
+  cugraph_type_erased_device_array_view_t* dst_view;
+
+  src_view = cugraph_coo_get_sources(coo);
+  dst_view = cugraph_coo_get_destinations(coo);
+
+  size_t src_size = cugraph_type_erased_device_array_view_size(src_view);
+
+  vertex_t h_src[src_size];
+  vertex_t h_dst[src_size];
+
+  ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+    handle, (byte_t*)h_src, src_view, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_to_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+    handle, (byte_t*)h_dst, dst_view, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst copy_to_host failed.");
+
+  for (int i = 0 ; i < src_size ; ++i) {
+    TEST_ASSERT(test_ret_value,
+                expected_src[i] == h_src[i],
+                "generated edges don't match");
+    TEST_ASSERT(test_ret_value,
+                expected_dst[i] == h_dst[i],
+                "generated edges don't match");
+  }
+
+  cugraph_type_erased_device_array_view_free(dst_view);
+  cugraph_type_erased_device_array_view_free(src_view);
+  cugraph_coo_free(coo);
+  cugraph_free_resource_handle(handle);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+int test_rmat_list_generation()
+{
+  int test_ret_value = 0;
+
+  typedef int32_t vertex_t;
+  typedef int32_t edge_t;
+  typedef float weight_t;
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error;
+
+  cugraph_resource_handle_t* handle = NULL;
+  cugraph_rng_state_t *rng_state    = NULL;;
+  cugraph_coo_list_t *coo_list = NULL;
+
+  handle = cugraph_create_resource_handle(NULL);
+  TEST_ASSERT(test_ret_value, handle != NULL, "resource handle creation failed.");
+
+  ret_code = cugraph_rng_state_create(handle, 0, &rng_state, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "rng_state create failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+
+  //
+  // NOTE: We can't exactly compare results for functions that make multiple RNG calls
+  // within them.  When the RNG state is advanced, it is advanced by a multiple of
+  // the number of possible threads involved, not based on how many of the values
+  // were actually used.  So different GPU versions will result in subtly different
+  // random sequences.
+  //
+  size_t   num_lists = 3;
+  vertex_t max_vertex_id[] = { 32, 16, 32 };
+  size_t   expected_len[]  = { 20, 16, 20 };
+  
+  ret_code = cugraph_rng_state_create(handle, 0, &rng_state, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "rng_state create failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+
+  ret_code = cugraph_generate_rmat_edgelists(handle,
+                                             rng_state,
+                                             num_lists,
+                                             4,
+                                             6,
+                                             4,
+                                             UNIFORM,
+                                             POWER_LAW,
+                                             FALSE,
+                                             &coo_list,
+                                             &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "generate_rmat_edgelist failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+
+  TEST_ASSERT(test_ret_value, cugraph_coo_list_size(coo_list) == num_lists, "generated wrong number of results");
+
+  for (size_t i = 0 ; (i < num_lists) && (test_ret_value == 0) ; i++) {
+    cugraph_coo_t *coo = NULL;
+
+    coo = cugraph_coo_list_element(coo_list, i);
+
+    cugraph_type_erased_device_array_view_t* src_view;
+    cugraph_type_erased_device_array_view_t* dst_view;
+
+    src_view = cugraph_coo_get_sources(coo);
+    dst_view = cugraph_coo_get_destinations(coo);
+
+    size_t src_size = cugraph_type_erased_device_array_view_size(src_view);
+
+    TEST_ASSERT(test_ret_value, src_size == expected_len[i], "wrong number of edges");
+
+    vertex_t h_src[src_size];
+    vertex_t h_dst[src_size];
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      handle, (byte_t*)h_src, src_view, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_to_host failed.");
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      handle, (byte_t*)h_dst, dst_view, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst copy_to_host failed.");
+
+    for (size_t j = 0 ; (j < src_size) && (test_ret_value == 0) ; ++j) {
+      TEST_ASSERT(test_ret_value,
+                  h_src[j] < max_vertex_id[i],
+                  "generated edges don't match");
+      TEST_ASSERT(test_ret_value,
+                  h_dst[j] < max_vertex_id[i],
+                  "generated edges don't match");
+    }
+
+    cugraph_type_erased_device_array_view_free(dst_view);
+    cugraph_type_erased_device_array_view_free(src_view);
+  }
+
+  cugraph_coo_list_free(coo_list);
+  cugraph_free_resource_handle(handle);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+/******************************************************************************/
+
+int main(int argc, char** argv)
+{
+  int result = 0;
+  result |= RUN_TEST(test_rmat_generation);
+  result |= RUN_TEST(test_rmat_list_generation);
+  return result;
+}

--- a/cpp/tests/c_api/mg_generate_rmat_test.c
+++ b/cpp/tests/c_api/mg_generate_rmat_test.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mg_test_utils.h" /* RUN_TEST */
+
+#include <cugraph_c/graph_generators.h>
+
+#include <stdio.h>
+
+/*
+ * Simple rmat generator test
+ */
+int test_rmat_generation(const cugraph_resource_handle_t* handle)
+{
+  int test_ret_value = 0;
+
+  typedef int32_t vertex_t;
+  typedef int32_t edge_t;
+  typedef float weight_t;
+
+  vertex_t expected_src_0[] =  { 17, 18, 0, 16, 1, 24, 16, 1, 6, 4, 2, 1, 14, 2, 16, 2, 5, 23, 4, 10, 4, 3, 0, 4, 11, 0, 0, 2, 24, 0};
+  vertex_t expected_dst_0[] = { 0, 10, 23, 0, 26, 0, 2, 1, 27, 8, 1, 0, 21, 21, 0, 4, 8, 14, 10, 17, 0, 16, 0, 16, 25, 5, 8, 8, 4, 19}; 
+  vertex_t expected_src_1[] = {1,0,2,25,0,5,18,0,0,2,4,0,8,9,2,2,9,16,4,1,0,2,0,0,9,5,4,6,4,9};
+  vertex_t expected_dst_1[] = {4,1,4,0,16,16,16,3,2,0,1,0,7,0,2,13,6,8,18,16,0,4,27,16,24,17,21,25,1,0};
+  vertex_t expected_src_2[] = {4,4,4,0,2,8,6,0,0,0,0,16,8,18,1,19,16,0,24,4,0,17,0,8,5,8,8,12,10,1};
+  vertex_t expected_dst_2[] = {9,2,3,18,0,24,2,4,0,0,25,0,0,4,20,0,16,10,17,16,25,16,1,1,4,24,6,6,0,0};
+  vertex_t expected_src_3[] = {9,16,0,1,4,26,7,20,0,0,0,25,2,16,4,12,18,2,16,24,5,20,1,4,1,22,9,1,2,16};
+  vertex_t expected_dst_3[] = {18,0,16,2,1,2,16,0,5,2,22,8,6,11,0,17,0,2,0,6,9,1,0,8,8,9,4,2,3,18};
+  vertex_t expected_src_4[] = {16,24,25,0,18,0,0,0,0,0,16,0,1,8,8,0,4,0,4,0,5,8,0,2,21,11,0,24,0,4};
+  vertex_t expected_dst_4[] = {8,13,16,0,0,2,17,18,16,14,4,0,0,1,4,2,1,0,1,0,0,0,26,0,20,1,14,21,2,28};
+  vertex_t expected_src_5[] = {0,24,8,2,6,0,10,4,4,0,10,4,17,0,17,0,10,20,26,0,6,0,11,2,1,0,17,2,4,8};
+  vertex_t expected_dst_5[] = {2,24,0,18,0,0,1,0,14,18,16,19,1,0,8,29,12,1,8,8,0,22,4,12,2,1,0,0,8,8};
+  vertex_t expected_src_6[] = {4,4,10,8,26,0,20,2,14,1,8,1,0,16,24,28,8,18,7,5,16,2,12,22,8,4,1,1,12,8};
+  vertex_t expected_dst_6[] = {4,2,6,1,3,16,5,8,5,0,19,9,0,1,0,0,8,26,0,9,16,0,3,6,2,24,8,0,4,10};
+  vertex_t expected_src_7[] = {5,0,16,0,16,21,1,3,8,4,0,22,25,8,0,4,0,6,0,0,0,0,2,0,0,4,8,0,0,0};
+  vertex_t expected_dst_7[] = {0,4,30,10,5,0,24,0,0,4,18,8,3,10,9,1,0,10,2,0,2,16,3,0,14,16,1,26,8,8};
+
+  vertex_t *expected_src[] = { expected_src_0, expected_src_1, expected_src_2, expected_src_3, expected_src_4, expected_src_5, expected_src_6, expected_src_7 };
+  vertex_t *expected_dst[] = { expected_dst_0, expected_dst_1, expected_dst_2, expected_dst_3, expected_dst_4, expected_dst_5, expected_dst_6, expected_dst_7 };
+  size_t    expected_len[] = { sizeof(expected_src_0) / sizeof(expected_src_0[0]),
+                               sizeof(expected_src_1) / sizeof(expected_src_1[0]),
+                               sizeof(expected_src_2) / sizeof(expected_src_2[0]),
+                               sizeof(expected_src_3) / sizeof(expected_src_3[0]),
+                               sizeof(expected_src_4) / sizeof(expected_src_4[0]),
+                               sizeof(expected_src_5) / sizeof(expected_src_5[0]),
+                               sizeof(expected_src_6) / sizeof(expected_src_6[0]),
+                               sizeof(expected_src_7) / sizeof(expected_src_7[0]) };
+
+  size_t max_rank_to_validate = sizeof(expected_src) / sizeof(expected_src[0]);
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error;
+
+  cugraph_rng_state_t *rng_state    = NULL;;
+  cugraph_coo_t *coo = NULL;
+
+  int rank = cugraph_resource_handle_get_rank(handle);
+
+  ret_code = cugraph_rng_state_create(handle, rank, &rng_state, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "rng_state create failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+ 
+  data_type_id_t vertex_tid = INT32;
+  data_type_id_t edge_tid   = INT32;
+  data_type_id_t weight_tid = FLOAT32;
+
+  ret_code = cugraph_generate_rmat_edgelist(handle,
+                                 rng_state,
+                                 5,
+                                 30,
+                                 0.57,
+                                 0.19,
+                                 0.19,
+                                 FALSE,
+                                 &coo,
+                                 &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "generate_rmat_edgelist failed.");
+
+  if (rank < max_rank_to_validate) {
+    cugraph_type_erased_device_array_view_t* src_view;
+    cugraph_type_erased_device_array_view_t* dst_view;
+
+    src_view = cugraph_coo_get_sources(coo);
+    dst_view = cugraph_coo_get_destinations(coo);
+
+    size_t src_size = cugraph_type_erased_device_array_view_size(src_view);
+
+    vertex_t h_src[src_size];
+    vertex_t h_dst[src_size];
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      handle, (byte_t*)h_src, src_view, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_to_host failed.");
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      handle, (byte_t*)h_dst, dst_view, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst copy_to_host failed.");
+
+    TEST_ASSERT(test_ret_value, src_size == expected_len[rank], "incorrect number of edges");
+
+    for (int i = 0 ; (i < src_size) && (test_ret_value == 0) ; ++i) {
+      TEST_ASSERT(test_ret_value,
+                  expected_src[rank][i] == h_src[i],
+                  "generated edges don't match");
+      TEST_ASSERT(test_ret_value,
+                  expected_dst[rank][i] == h_dst[i],
+                  "generated edges don't match");
+    }
+
+    cugraph_type_erased_device_array_view_free(dst_view);
+    cugraph_type_erased_device_array_view_free(src_view);
+  }
+
+  cugraph_coo_free(coo);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+int test_rmat_list_generation(const cugraph_resource_handle_t* handle)
+{
+  int test_ret_value = 0;
+
+  typedef int32_t vertex_t;
+  typedef int32_t edge_t;
+  typedef float weight_t;
+
+  size_t num_lists = 3;
+
+  vertex_t expected_src_0_rank_0[] = { 29,16,16,5,6,1,20,5,22,14,3,12,4,0,10,0,4,16,20,16};
+  vertex_t expected_dst_0_rank_0[] = { 0,18,0,8,1,0,11,8,21,16,0,2,2,0,17,0,9,0,8,0};
+  vertex_t expected_src_1_rank_0[] = { 2,6,8,0,8,0,0,2,8,0,12,0,2,9,4,8};
+  vertex_t expected_dst_1_rank_0[] = { 10,5,0,4,10,5,4,1,0,1,11,0,0,6,2,14};
+  vertex_t expected_src_2_rank_0[] = { 5,0,24,11,2,20,2,1,0,18,2,0,0,0,8,4,1,22,0,1};
+  vertex_t expected_dst_2_rank_0[] = { 16,4,0,1,8,0,0,0,8,7,3,15,0,0,4,26,16,0,8,2};
+  vertex_t expected_src_0_rank_1[] = { 0,21,10,17,8,0,21,24,0,0,0,1,2,16,0,2,2,24,0,27};
+  vertex_t expected_dst_0_rank_1[] = { 0,2,4,0,19,12,0,18,4,16,8,0,1,4,5,4,18,16,20,24};
+  vertex_t expected_src_1_rank_1[] = { 12,0,0,0,8,12,0,0,0,0,0,0,0,0,0,1};
+  vertex_t expected_dst_1_rank_1[] = { 12,8,1,0,8,0,1,0,6,13,0,0,0,0,0,2};
+  vertex_t expected_src_2_rank_1[] = { 4,12,0,0,1,12,2,0,16,0,20,8,14,0,16,9,24,8,10,1};
+  vertex_t expected_dst_2_rank_1[] = { 16,0,0,4,0,13,0,1,2,0,0,8,8,4,1,3,5,16,2,0};
+  vertex_t expected_src_0_rank_2[] = { 8,4,4,4,1,6,9,4,6,0,13,3,0,0,8,13};
+  vertex_t expected_dst_0_rank_2[] = { 6,0,6,2,0,0,1,0,6,0,10,0,2,2,12,0};
+  vertex_t expected_src_1_rank_2[] = { 18,12,2,0,12,4,1,18,0,4,0,3,0,0,18,22,3,4,2,8};
+  vertex_t expected_dst_1_rank_2[] = { 2,1,8,22,1,28,4,11,0,0,12,24,8,3,8,6,1,16,0,2};
+  vertex_t expected_src_2_rank_2[] = { 1,2,12,3,1,0,4,5,1,3,5,3,1,2,8,0};
+  vertex_t expected_dst_2_rank_2[] = { 8,0,0,4,4,4,2,10,1,13,0,0,0,4,0,4};
+  vertex_t expected_src_0_rank_3[] = { 0,13,0,2,16,4,10,1,20,2,0,0,1,0,16,3,6,10,0,0};
+  vertex_t expected_dst_0_rank_3[] = { 9,16,0,8,9,1,0,1,3,0,0,2,8,0,12,2,20,8,29,3};
+  vertex_t expected_src_1_rank_3[] = { 2,13,3,2,18,8,0,0,8,10,17,0,2,26,9,28,1,0,10,17};
+  vertex_t expected_dst_1_rank_3[] = { 2,8,0,14,16,20,8,8,0,0,7,0,16,4,20,16,5,3,0,3};
+  vertex_t expected_src_2_rank_3[] = { 0,1,3,0,9,1,5,0,4,4,0,6,0,12,0,2};
+  vertex_t expected_dst_2_rank_3[] = { 4,1,0,12,6,2,2,8,2,10,8,0,4,4,0,1};
+  vertex_t expected_src_0_rank_4[] = { 0,1,1,0,0,1,4,3,14,3,0,4,0,2,9,0};
+  vertex_t expected_dst_0_rank_4[] = { 0,2,8,0,2,0,13,0,0,8,1,12,0,9,0,0};
+  vertex_t expected_src_1_rank_4[] = { 2,2,2,6,4,6,4,10,0,2,2,8,4,0,4,9};
+  vertex_t expected_dst_1_rank_4[] = { 0,1,6,1,1,0,10,2,0,0,0,0,0,1,0,0};
+  vertex_t expected_src_2_rank_4[] = { 9,2,0,20,0,3,5,22,2,8,26,0,18,16,12,0,0,18,8,2};
+  vertex_t expected_dst_2_rank_4[] = { 2,8,6,18,16,16,19,0,16,1,0,0,12,0,8,0,0,8,22,4};
+  vertex_t expected_src_0_rank_5[] = { 8,11,4,4,8,0,8,15,12,6,1,0,7,4,3,2};
+  vertex_t expected_dst_0_rank_5[] = { 5,4,12,8,4,8,8,1,0,3,0,8,8,0,1,5};
+  vertex_t expected_src_1_rank_5[] = { 16,0,8,17,9,8,2,1,0,24,8,2,0,0,16,22,16,0,0,2};
+  vertex_t expected_dst_1_rank_5[] = { 8,10,2,0,0,6,8,2,8,16,1,0,24,26,0,0,2,3,8,24};
+  vertex_t expected_src_2_rank_5[] = { 21,5,10,24,1,16,10,0,2,2,5,4,2,0,0,8,2,0,4,4};
+  vertex_t expected_dst_2_rank_5[] = { 4,14,20,0,0,8,20,1,8,21,16,2,0,2,14,0,10,24,9,5};
+  vertex_t expected_src_0_rank_6[] = { 8,16,2,8,0,24,20,10,8,0,0,0,20,8,10,0,4,8,12,4};
+  vertex_t expected_dst_0_rank_6[] = { 21,25,6,6,2,0,12,1,8,8,16,28,8,1,10,0,1,0,16,2};
+  vertex_t expected_src_1_rank_6[] = { 4,0,1,13,0,1,10,8,2,0,9,8,3,6,4,12};
+  vertex_t expected_dst_1_rank_6[] = { 9,2,5,6,8,0,4,0,0,10,2,6,14,0,0,2};
+  vertex_t expected_src_2_rank_6[] = { 2,4,18,18,0,24,4,16,5,18,17,13,16,28,24,0,28,0,13,1};
+  vertex_t expected_dst_2_rank_6[] = { 8,24,24,1,16,2,0,4,1,0,10,10,18,0,18,18,2,26,8,0};
+  vertex_t expected_src_0_rank_7[] = { 0,5,0,4,2,3,4,4,20,18,0,0,29,17,0,0,0,1,0,8};
+  vertex_t expected_dst_0_rank_7[] = { 4,0,24,0,0,18,8,0,0,9,3,12,4,8,17,1,0,28,22,1};
+  vertex_t expected_src_1_rank_7[] = { 0,8,5,2,4,0,0,5,0,0,0,9,2,0,2,8};
+  vertex_t expected_dst_1_rank_7[] = { 3,0,1,9,9,8,7,12,1,12,5,0,0,8,13,8};
+  vertex_t expected_src_2_rank_7[] = { 8,9,2,4,4,0,25,0,0,0,8,6,0,0,8,4,21,0,16,0};
+  vertex_t expected_dst_2_rank_7[] = { 4,4,1,1,4,0,16,1,0,16,5,25,24,8,16,2,2,0,4,16};
+
+  vertex_t *expected_src_0[] = { expected_src_0_rank_0, expected_src_0_rank_1, expected_src_0_rank_2, expected_src_0_rank_3,
+                                 expected_src_0_rank_4, expected_src_0_rank_5, expected_src_0_rank_6, expected_src_0_rank_7 };
+  vertex_t *expected_dst_0[] = { expected_dst_0_rank_0, expected_dst_0_rank_1, expected_dst_0_rank_2, expected_dst_0_rank_3,
+                                 expected_dst_0_rank_4, expected_dst_0_rank_5, expected_dst_0_rank_6, expected_dst_0_rank_7 };
+  vertex_t *expected_src_1[] = { expected_src_1_rank_0, expected_src_1_rank_1, expected_src_1_rank_2, expected_src_1_rank_3,
+                                 expected_src_1_rank_4, expected_src_1_rank_5, expected_src_1_rank_6, expected_src_1_rank_7 };
+  vertex_t *expected_dst_1[] = { expected_dst_1_rank_0, expected_dst_1_rank_1, expected_dst_1_rank_2, expected_dst_1_rank_3,
+                                 expected_dst_1_rank_4, expected_dst_1_rank_5, expected_dst_1_rank_6, expected_dst_1_rank_7 };
+  vertex_t *expected_src_2[] = { expected_src_2_rank_0, expected_src_2_rank_1, expected_src_2_rank_2, expected_src_2_rank_3,
+                                 expected_src_2_rank_4, expected_src_2_rank_5, expected_src_2_rank_6, expected_src_2_rank_7 };
+  vertex_t *expected_dst_2[] = { expected_dst_2_rank_0, expected_dst_2_rank_1, expected_dst_2_rank_2, expected_dst_2_rank_3,
+                                 expected_dst_2_rank_4, expected_dst_2_rank_5, expected_dst_2_rank_6, expected_dst_2_rank_7 };
+
+  size_t    expected_len_0[] = { sizeof(expected_src_0_rank_0) / sizeof(expected_src_0_rank_0[0]),
+                                 sizeof(expected_src_0_rank_1) / sizeof(expected_src_0_rank_1[0]),
+                                 sizeof(expected_src_0_rank_2) / sizeof(expected_src_0_rank_2[0]),
+                                 sizeof(expected_src_0_rank_3) / sizeof(expected_src_0_rank_3[0]),
+                                 sizeof(expected_src_0_rank_4) / sizeof(expected_src_0_rank_4[0]),
+                                 sizeof(expected_src_0_rank_5) / sizeof(expected_src_0_rank_5[0]),
+                                 sizeof(expected_src_0_rank_6) / sizeof(expected_src_0_rank_6[0]),
+                                 sizeof(expected_src_0_rank_7) / sizeof(expected_src_0_rank_7[0]) };
+  
+  size_t    expected_len_1[] = { sizeof(expected_src_1_rank_0) / sizeof(expected_src_1_rank_0[0]),
+                                 sizeof(expected_src_1_rank_1) / sizeof(expected_src_1_rank_1[0]),
+                                 sizeof(expected_src_1_rank_2) / sizeof(expected_src_1_rank_2[0]),
+                                 sizeof(expected_src_1_rank_3) / sizeof(expected_src_1_rank_3[0]),
+                                 sizeof(expected_src_1_rank_4) / sizeof(expected_src_1_rank_4[0]),
+                                 sizeof(expected_src_1_rank_5) / sizeof(expected_src_1_rank_5[0]),
+                                 sizeof(expected_src_1_rank_6) / sizeof(expected_src_1_rank_6[0]),
+                                 sizeof(expected_src_1_rank_7) / sizeof(expected_src_1_rank_7[0]) };
+  
+  size_t    expected_len_2[] = { sizeof(expected_src_2_rank_0) / sizeof(expected_src_2_rank_0[0]),
+                                 sizeof(expected_src_2_rank_1) / sizeof(expected_src_2_rank_1[0]),
+                                 sizeof(expected_src_2_rank_2) / sizeof(expected_src_2_rank_2[0]),
+                                 sizeof(expected_src_2_rank_3) / sizeof(expected_src_2_rank_3[0]),
+                                 sizeof(expected_src_2_rank_4) / sizeof(expected_src_2_rank_4[0]),
+                                 sizeof(expected_src_2_rank_5) / sizeof(expected_src_2_rank_5[0]),
+                                 sizeof(expected_src_2_rank_6) / sizeof(expected_src_2_rank_6[0]),
+                                 sizeof(expected_src_2_rank_7) / sizeof(expected_src_2_rank_7[0]) };
+
+  vertex_t **expected_src[] = { expected_src_0, expected_src_1, expected_src_2 };
+  vertex_t **expected_dst[] = { expected_dst_0, expected_dst_1, expected_dst_2 };
+  size_t    *expected_len[] = { expected_len_0, expected_len_1, expected_len_2 };
+
+  size_t max_rank_to_validate = sizeof(expected_src_0) / sizeof(expected_src_0[0]);
+  
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error;
+
+  cugraph_rng_state_t *rng_state    = NULL;;
+  cugraph_coo_list_t *coo_list = NULL;
+
+  int rank = cugraph_resource_handle_get_rank(handle);
+
+  ret_code = cugraph_rng_state_create(handle, rank, &rng_state, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "rng_state create failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+ 
+  data_type_id_t vertex_tid = INT32;
+  data_type_id_t edge_tid   = INT32;
+  data_type_id_t weight_tid = FLOAT32;
+
+  ret_code = cugraph_generate_rmat_edgelists(handle,
+                                             rng_state,
+                                             num_lists,
+                                             4,
+                                             6,
+                                             4,
+                                             UNIFORM,
+                                             POWER_LAW,
+                                             FALSE,
+                                             &coo_list,
+                                             &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "generate_rmat_edgelist failed.");
+
+  TEST_ASSERT(test_ret_value, cugraph_coo_list_size(coo_list) == num_lists, "generated wrong number of results");
+
+  if (rank < max_rank_to_validate) {
+    for (size_t i = 0 ; (i < num_lists) && (test_ret_value == 0) ; i++) {
+      cugraph_coo_t *coo = NULL;
+
+      coo = cugraph_coo_list_element(coo_list, i);
+
+      cugraph_type_erased_device_array_view_t* src_view;
+      cugraph_type_erased_device_array_view_t* dst_view;
+
+      src_view = cugraph_coo_get_sources(coo);
+      dst_view = cugraph_coo_get_destinations(coo);
+
+      size_t src_size = cugraph_type_erased_device_array_view_size(src_view);
+
+      TEST_ASSERT(test_ret_value, src_size == expected_len[i][rank], "wrong number of edges");
+
+      vertex_t h_src[src_size];
+      vertex_t h_dst[src_size];
+
+      ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+        handle, (byte_t*)h_src, src_view, &ret_error);
+      TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_to_host failed.");
+
+      ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+        handle, (byte_t*)h_dst, dst_view, &ret_error);
+      TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst copy_to_host failed.");
+
+      for (size_t j = 0 ; (j < src_size) && (test_ret_value == 0) ; ++j) {
+        TEST_ASSERT(test_ret_value,
+                    expected_src[i][rank][j] == h_src[j],
+                    "generated edges don't match");
+        TEST_ASSERT(test_ret_value,
+                    expected_dst[i][rank][j] == h_dst[j],
+                    "generated edges don't match");
+      }
+
+      cugraph_type_erased_device_array_view_free(dst_view);
+      cugraph_type_erased_device_array_view_free(src_view);
+    }
+  }
+
+  cugraph_coo_list_free(coo_list);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+/******************************************************************************/
+
+int main(int argc, char** argv)
+{
+  void* raft_handle                 = create_mg_raft_handle(argc, argv);
+  cugraph_resource_handle_t* handle = cugraph_create_resource_handle(raft_handle);
+
+  int result = 0;
+  result |= RUN_MG_TEST(test_rmat_generation, handle);
+  result |= RUN_MG_TEST(test_rmat_list_generation, handle);
+
+  cugraph_free_resource_handle(handle);
+  free_mg_raft_handle(raft_handle);
+
+  return result;
+}

--- a/cpp/tests/cores/core_number_test.cpp
+++ b/cpp/tests/cores/core_number_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -270,7 +270,7 @@ class Tests_CoreNumber
       if (renumber) {
         std::tie(unrenumbered_graph, std::ignore, std::ignore) =
           cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, false>(
-            handle, input_usecase, true, false, true, true);
+            handle, input_usecase, false, false, true, true);
       }
       auto unrenumbered_graph_view = renumber ? unrenumbered_graph.view() : graph_view;
 

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -212,6 +212,7 @@ inline auto parse_test_options(int argc, char** argv)
       (cmd_opts.count("test_file_name") > 0)                                            \
         ? std::make_optional<std::string>(cmd_opts["test_file_name"].as<std::string>()) \
         : std::nullopt;                                                                 \
+                                                                                        \
     return RUN_ALL_TESTS();                                                             \
   }
 
@@ -242,6 +243,7 @@ inline auto parse_test_options(int argc, char** argv)
       (cmd_opts.count("test_file_name") > 0)                                            \
         ? std::make_optional<std::string>(cmd_opts["test_file_name"].as<std::string>()) \
         : std::nullopt;                                                                 \
+                                                                                        \
     auto ret = RUN_ALL_TESTS();                                                         \
     cugraph::test::finalize_mpi();                                                      \
     return ret;                                                                         \

--- a/cpp/tests/utilities/test_graphs.hpp
+++ b/cpp/tests/utilities/test_graphs.hpp
@@ -21,8 +21,12 @@
 #include <cugraph/graph_generators.hpp>
 #include <cugraph/legacy/functions.hpp>  // legacy coo_to_csr
 
+#include <raft/random/rng_state.hpp>
+
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
+
+#include <memory>
 
 namespace cugraph {
 namespace test {
@@ -259,6 +263,7 @@ class Rmat_Usecase : public detail::TranslateGraph_Usecase {
     }
 
     // 2. generate edges
+    raft::random::RngState rng_state{seed_};
 
     std::vector<rmm::device_uvector<vertex_t>> src_partitions{};
     std::vector<rmm::device_uvector<vertex_t>> dst_partitions{};
@@ -273,21 +278,18 @@ class Rmat_Usecase : public detail::TranslateGraph_Usecase {
 
       auto [tmp_src_v, tmp_dst_v] =
         cugraph::generate_rmat_edgelist<vertex_t>(handle,
+                                                  rng_state,
                                                   scale_,
                                                   partition_edge_counts[i],
                                                   a_,
                                                   b_,
                                                   c_,
-                                                  seed_ + id,
                                                   undirected_ ? true : false);
 
       std::optional<rmm::device_uvector<weight_t>> tmp_weights_v{std::nullopt};
       if (weight_partitions) {
         tmp_weights_v =
           std::make_optional<rmm::device_uvector<weight_t>>(tmp_src_v.size(), handle.get_stream());
-
-        // FIXME: This should be refactored to create a single RngState and reuse it
-        raft::random::RngState rng_state{seed_ + num_partitions + id};
 
         cugraph::detail::uniform_random_fill(handle.get_stream(),
                                              tmp_weights_v->data(),

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -203,7 +203,6 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - ogb
           - py
           - pytest
           - pytest-cov

--- a/python/cugraph-dgl/cugraph_dgl/dataloading/utils/sampling_helpers.py
+++ b/python/cugraph-dgl/cugraph_dgl/dataloading/utils/sampling_helpers.py
@@ -21,6 +21,11 @@ torch = import_optional("torch")
 
 
 def cast_to_tensor(ser: cudf.Series):
+    if len(ser) == 0:
+        # Empty series can not be converted to pytorch cuda tensor
+        t = torch.from_numpy(ser.values.get())
+        return t.to("cuda")
+
     return torch.as_tensor(ser.values, device="cuda")
 
 

--- a/python/cugraph-dgl/tests/test_utils.py
+++ b/python/cugraph-dgl/tests/test_utils.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cudf
+import cupy as cp
+import torch
+
+from cugraph_dgl.dataloading.utils.sampling_helpers import cast_to_tensor
+
+
+def test_casting_empty_array():
+    ar = cp.zeros(shape=0, dtype=cp.int32)
+    ser = cudf.Series(ar)
+    output_tensor = cast_to_tensor(ser)
+    assert output_tensor.dtype == torch.int32

--- a/python/cugraph/cugraph/sampling/random_walks.py
+++ b/python/cugraph/cugraph/sampling/random_walks.py
@@ -102,7 +102,7 @@ def random_walks(
             "supported in the next releases. only padded paths will be "
             "returned instead"
         )
-    warnings.warn(warning_msg, PendingDeprecationWarning)
+        warnings.warn(warning_msg, PendingDeprecationWarning)
 
     if max_depth is None:
         raise TypeError("must specify a 'max_depth'")

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_generators.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_generators.pxd
@@ -1,0 +1,145 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Have cython use python 3 syntax
+# cython: language_level = 3
+
+from pylibcugraph._cugraph_c.resource_handle cimport (
+    cugraph_resource_handle_t,
+    bool_t,
+)
+from pylibcugraph._cugraph_c.error cimport (
+    cugraph_error_code_t,
+    cugraph_error_t,
+)
+from pylibcugraph._cugraph_c.array cimport (
+    cugraph_type_erased_device_array_view_t,
+    cugraph_type_erased_host_array_view_t,
+)
+from pylibcugraph._cugraph_c.random cimport (
+    cugraph_rng_state_t,
+)
+
+cdef extern from "cugraph_c/graph_generators.h":
+    ctypedef enum cugraph_generator_distribution_t:
+        POWER_LAW
+        UNIFORM
+
+    ctypedef struct cugraph_coo_t:
+        pass
+
+    ctypedef struct cugraph_coo_list_t:
+        pass
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_coo_get_sources(
+            cugraph_coo_t* coo
+        )
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_coo_get_destinations(
+            cugraph_coo_t* coo
+        )
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_coo_get_edge_weights(
+            cugraph_coo_t* coo
+        )
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_coo_get_edge_id(
+            cugraph_coo_t* coo
+        )
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_coo_get_edge_type(
+            cugraph_coo_t* coo
+        )
+
+    cdef size_t \
+        cugraph_coo_list_size(
+            const cugraph_coo_list_t* coo_list
+        )
+
+    cdef cugraph_coo_t* \
+        cugraph_coo_list_element(
+            cugraph_coo_list_t* coo_list,
+            size_t index)
+
+    cdef void \
+        cugraph_coo_free(
+            cugraph_coo_t* coo
+        )
+
+    cdef void \
+        cugraph_list_coo_free(
+            cugraph_coo_list_t* coo_list
+        )
+
+    cdef cugraph_error_code_t \
+        cugraph_generate_rmat_edgelist(
+            const cugraph_resource_handle_t* handle,
+            cugraph_rng_state_t* rng_state,
+            size_t scale,
+            size_t num_edges,
+            double a,
+            double b,
+            double c,
+            bool clip_and_flip,
+            cugraph_coo_t** result,
+            cugraph_error_t** error
+        )
+
+    cdef cugraph_error_code_t \
+        cugraph_generate_rmat_edgelists(
+            const cugraph_resource_handle_t* handle,
+            cugraph_rng_state_t* rng_state,
+            size_t n_edgelists,
+            size_t min_scale,
+            size_t max_scale,
+            size_t edge_factor,
+            cugraph_generator_distribution_t size_distribution,
+            cugraph_generator_distribution_t edge_distribution,
+            bool_t clip_and_flip,
+            cugraph_coo_list_t** result,
+            cugraph_error_t** error
+        )
+
+    cdef cugraph_error_code_t \
+        cugraph_generate_edge_weights(
+            const cugraph_resource_handle_t* handle,
+            cugraph_rng_state_t* rng_state,
+            cugraph_coo_t* coo,
+            cugraph_data_type_id_t dtype,
+            double minimum_weight,
+            double maximum_weight,
+            cugraph_error_t** error
+        )
+
+    cdef cugraph_error_code_t \
+        cugraph_generate_edge_ids(
+            const cugraph_resource_handle_t* handle,
+            cugraph_coo_t* coo,
+            bool_t multi_gpu,
+            cugraph_error_t** error
+        )
+
+    cdef cugraph_error_code_t \
+        cugraph_generate_edge_types(
+            const cugraph_resource_handle_t* handle,
+            cugraph_rng_state_t* rng_state,
+            cugraph_coo_t* coo,
+            int32_t min_edge_type,
+            int32_t max_edge_type,
+            cugraph_error_t** error
+        )


### PR DESCRIPTION
Missing indentation leading to an `UnboundedLocalError`.

In line 105 of the file `python/cugraph/cugraph/sampling/random_walks.py`, the `warn` call uses the `warning_msg` variable which is only defined inside the preceding if statement. This leads to the error:
```
UnboundLocalError: local variable 'warning_msg' referenced before assignment
```
When calling the `random_walks` function with `legacy_result_type == False`.